### PR TITLE
fix(DEIPWorld/deip-wallet) DW-62 Do not cast number to exponential

### DIFF
--- a/src/services/ApiService.ts
+++ b/src/services/ApiService.ts
@@ -334,7 +334,7 @@ export class ApiService {
   ): Promise<ITransaction> {
     try {
       const hash = await this.api.tx.balances
-        .transfer(recipient, new BigNumber(amount).shiftedBy(18).toString())
+        .transfer(recipient, new BigNumber(amount).shiftedBy(18).toFixed())
         .signAndSend(account.pair);
 
       return {
@@ -352,7 +352,7 @@ export class ApiService {
   createMultisigTransaction(recipient: string, amount: number): IMultisigTransactionData {
     const transaction = this.api.tx.balances.transfer(
       recipient,
-      new BigNumber(amount).shiftedBy(18).toString()
+      new BigNumber(amount).shiftedBy(18).toFixed()
     );
 
     return {


### PR DESCRIPTION
BigNumber.toString casts numbers with 21+ zeroes into exponential format '1e+21'.
BigNumber.toFixed leaves plain format